### PR TITLE
Add a playbook for installing devtools such as docker

### DIFF
--- a/devtools-playbook.yml
+++ b/devtools-playbook.yml
@@ -1,0 +1,10 @@
+---
+# Install development tools
+
+- name: Install Docker
+  become: yes
+  hosts: demo
+  roles:
+    - docker
+
+

--- a/devtools-playbook.yml
+++ b/devtools-playbook.yml
@@ -2,7 +2,6 @@
 # Install development tools
 
 - name: Install Docker
-  become: yes
   hosts: demo
   roles:
     - docker


### PR DESCRIPTION
Currently the new playbook only installs docker. But later we may add more development tools if necessary.
