### PR TITLE
Do not restart syndicate-ms daemon until it finishes setting up

### DIFF
--- a/roles/syndicate-ms/tasks/main.yml
+++ b/roles/syndicate-ms/tasks/main.yml
@@ -102,8 +102,6 @@
   args:
     chdir: "{{ ms_path }}"
     creates: "{{ ms_path }}/app.yaml"
-  notify:
-    - restart-syndicate-ms
 
 - name: Adjust syndicate directory ownerships
   file:
@@ -139,9 +137,9 @@
   with_items:
     - syndicate-ms
 
-- name: Start syndicate processes
+- name: Restart syndicate processes
   service:
     name: "{{ item }}"
-    state: started
+    state: restarted
   with_items:
     - syndicate-ms


### PR DESCRIPTION
Do not restart syndicate-ms daemon until it finishes setting up
